### PR TITLE
fix: Fix issues with do_cluster_version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,7 @@ module "digital_ocean" {
   source          = "./modules/digital-ocean"
   do_cluster_name = var.do_cluster_name
   do_alert_email  = var.do_alert_email
+  do_cluster_version = var.do_cluster_version
 }
 
 module "kubernetes" {

--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,9 @@ provider "kubectl" {
 }
 
 module "digital_ocean" {
-  source          = "./modules/digital-ocean"
-  do_cluster_name = var.do_cluster_name
-  do_alert_email  = var.do_alert_email
+  source             = "./modules/digital-ocean"
+  do_cluster_name    = var.do_cluster_name
+  do_alert_email     = var.do_alert_email
   do_cluster_version = var.do_cluster_version
 }
 

--- a/modules/digital-ocean/cluster.tf
+++ b/modules/digital-ocean/cluster.tf
@@ -2,17 +2,15 @@ variable "do_cluster_name" {
   description = "Kubernetes cluster name on DigitalOcean"
 }
 
+variable "do_cluster_version" {
+  description = "The slug identifier for the version of Kubernetes used for the cluster"
+}
+
 variable "do_cluster_region" {
   # list is available at https://slugs.do-api.dev/ on "Regions"
   # default is - New York 1
   description = "The slug identifier for the region where the Kubernetes cluster will be created"
   default     = "nyc1"
-}
-
-variable "do_cluster_version" {
-  # list is available at https://slugs.do-api.dev/ on "Kubernetes Versions"
-  description = "The slug identifier for the version of Kubernetes used for the cluster"
-  default     = "1.27.10-do.0"
 }
 
 variable "do_cluster_node_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,8 @@ variable "do_token" {
 variable "do_alert_email" {
   description = "Email address to be used for sending resource utilization alerts"
 }
+
+variable "do_cluster_version" {
+  # list is available at https://slugs.do-api.dev/ on "Kubernetes Versions"
+  description = "The slug identifier for the version of Kubernetes used for the cluster"
+}


### PR DESCRIPTION
## Description

This changes makes the variable `do_cluster_version` required now. This was done as DigitalOcean's kubernetes cluster version keeps on changing and if we try to use an older one, then it will encounter error.