### PR TITLE
 Added preview node pool with automated lifecycle via GitHubaction

### DIFF
--- a/.github/workflows/disable_preview_pool.yml
+++ b/.github/workflows/disable_preview_pool.yml
@@ -1,0 +1,122 @@
+name: Disable Preview Pool
+
+on:
+  repository_dispatch:
+    types: [disable-preview-pool]
+  workflow_dispatch:
+
+# Prevent concurrent runs with preview pool operations to avoid state conflicts
+concurrency:
+  group: terraform-preview-pool-operations
+  cancel-in-progress: false
+
+jobs:
+  disable-preview-pool:
+    name: Disable Preview Pool
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+        terraform_wrapper: false  # Disable wrapper for better error handling
+        
+    - name: Terraform Init
+      run: |
+        echo " Initializing Terraform..."
+        terraform init
+        echo " Terraform initialization completed"
+        
+    - name: Terraform Validate
+      run: |
+        echo " Validating Terraform configuration..."
+        terraform validate
+        echo " Terraform configuration is valid"
+      
+    - name: Check Current Preview Pool State
+      id: current-state
+      run: |
+        echo " Checking current preview pool state..."
+        set +e  # Don't exit on error
+        
+        echo " Fetching current Terraform state..."
+        if terraform state list > state_resources.txt 2>/dev/null; then
+          echo " Successfully retrieved Terraform state"
+        else
+          echo " Could not retrieve Terraform state - assuming no resources exist"
+          touch state_resources.txt  # Create empty file for consistent processing
+        fi
+        
+        if grep -q "module.digital_ocean.digitalocean_kubernetes_node_pool.do_cluster_staging_pool" state_resources.txt; then
+          echo " Preview pool found in state - proceeding with disable"
+          echo "pool-exists=true" >> $GITHUB_OUTPUT
+        else
+          echo " Preview pool not found in state - already disabled"
+          echo "pool-exists=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Terraform Plan - Disable Preview Pool
+      if: steps.current-state.outputs.pool-exists == 'true'
+      run: |
+        echo " Terraform plan to disable preview pool:"
+        terraform plan -var="enable_preview_pool=false" -no-color
+      
+    - name: Terraform Apply - Disable Preview Pool
+      if: steps.current-state.outputs.pool-exists == 'true'
+      run: |
+        echo " Disabling preview pool..."
+        echo " This will save ~$14/month in costs"
+        
+        terraform apply -auto-approve -var="enable_preview_pool=false"
+        
+        if [ $? -eq 0 ]; then
+          echo " Preview pool successfully disabled"
+          echo " Cost savings activated - preview resources destroyed"
+        else
+          echo " Failed to disable preview pool"
+          exit 1
+        fi
+      
+    - name: Already Disabled
+      if: steps.current-state.outputs.pool-exists == 'false'
+      run: |
+        echo " Preview pool is already disabled - no action needed"
+        echo " Cost optimization is already active"
+        
+    - name: Cleanup Temporary Files
+      if: always()
+      run: |
+        echo " Cleaning up temporary files..."
+        rm -f state_resources.txt || true
+        echo " Cleanup completed"
+        
+    - name: Workflow Summary
+      if: always()
+      run: |
+        echo "##  Disable Preview Pool Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- **Pool existed**: ${{ steps.current-state.outputs.pool-exists }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Workflow status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+        
+        if [ "${{ steps.current-state.outputs.pool-exists }}" == "true" ] && [ "${{ job.status }}" == "success" ]; then
+          echo "- **Action taken**:  Successfully disabled preview pool (saving ~$14/month)" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ steps.current-state.outputs.pool-exists }}" == "false" ]; then
+          echo "- **Action taken**:  No action needed - pool already disabled" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- **Action taken**: Failed to disable preview pool" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+    - name: Notify Success
+      if: success() && steps.current-state.outputs.pool-exists == 'true'
+      run: |
+        echo " Preview pool has been successfully disabled"
+        echo " Cost savings: ~$14/month"
+        
+    - name: Notify Failure
+      if: failure()
+      run: |
+        echo " Failed to disable preview pool"
+        echo "Please check the logs and try again"

--- a/.github/workflows/ensure_preview_pool.yml
+++ b/.github/workflows/ensure_preview_pool.yml
@@ -1,0 +1,144 @@
+name: Ensure Preview Pool
+
+on:
+  repository_dispatch:
+    types: [ensure-preview-pool]
+  workflow_dispatch:
+
+# Prevent concurrent runs with any preview pool operations to avoid state conflicts
+concurrency:
+  group: terraform-preview-pool-operations
+  cancel-in-progress: false
+
+jobs:
+  ensure-preview-pool:
+    name: Enable Preview Pool
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+        terraform_wrapper: false  # Disable wrapper for better error handling
+        
+    - name: Terraform Init
+      run: |
+        echo " Initializing Terraform..."
+        terraform init
+        echo " Terraform initialization completed"
+        
+    - name: Terraform Validate
+      run: |
+        echo " Validating Terraform configuration..."
+        terraform validate
+        echo " Terraform configuration is valid"
+      
+    - name: Check Current Preview Pool State
+      id: current-state
+      run: |
+        echo " Checking current preview pool state..."
+        set +e  # Don't exit on error
+        
+        echo " Fetching current Terraform state..."
+        if terraform state list > state_resources.txt 2>/dev/null; then
+          echo " Successfully retrieved Terraform state"
+        else
+          echo " Could not retrieve Terraform state - assuming no resources exist"
+          touch state_resources.txt  # Create empty file for consistent processing
+        fi
+        
+        if grep -q "module.digital_ocean.digitalocean_kubernetes_node_pool.do_cluster_staging_pool" state_resources.txt; then
+          echo " Preview pool found in state - checking if already enabled"
+          
+          # Get resource details to check if it's actually running
+          RESOURCE_NAME=$(grep "module.digital_ocean.digitalocean_kubernetes_node_pool.do_cluster_staging_pool" state_resources.txt | head -1)
+          echo " Getting detailed resource information..."
+          if terraform state show "$RESOURCE_NAME" > pool_details.txt 2>/dev/null; then
+            echo " Successfully retrieved resource details"
+          else
+            echo " Could not retrieve resource details - assuming resource needs attention"
+            touch pool_details.txt  # Create empty file for consistent processing
+          fi
+          
+          if [ -s pool_details.txt ]; then
+            NODE_COUNT=$(grep -E "actual_node_count\s*=" pool_details.txt | head -1 | sed 's/.*= //' | sed 's/[^0-9]//g')
+            if [[ "$NODE_COUNT" -gt 0 ]]; then
+              echo " Preview pool is already enabled with $NODE_COUNT nodes"
+              echo "pool-enabled=true" >> $GITHUB_OUTPUT
+            else
+              echo " Preview pool exists but has 0 nodes - needs enabling"
+              echo "pool-enabled=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "pool-enabled=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo " Preview pool not found in state - needs creation"
+          echo "pool-enabled=false" >> $GITHUB_OUTPUT
+        fi
+        
+    - name: Terraform Plan - Enable Preview Pool
+      if: steps.current-state.outputs.pool-enabled == 'false'
+      run: |
+        echo " Terraform plan to enable preview pool:"
+        terraform plan -var="enable_preview_pool=true" -no-color
+      
+    - name: Terraform Apply - Enable Preview Pool
+      if: steps.current-state.outputs.pool-enabled == 'false'
+      run: |
+        echo " Enabling preview pool..."
+        echo " This will incur ~$14/month in costs"
+        
+        terraform apply -auto-approve -var="enable_preview_pool=true"
+        
+        if [ $? -eq 0 ]; then
+          echo " Preview pool successfully enabled"
+          echo " Preview environment is now available for PR testing"
+        else
+          echo " Failed to enable preview pool"
+          exit 1
+        fi
+      
+    - name: Already Enabled
+      if: steps.current-state.outputs.pool-enabled == 'true'
+      run: |
+        echo " Preview pool is already enabled - no action needed"
+        echo " Preview environment is ready for development"
+        
+    - name: Cleanup Temporary Files
+      if: always()
+      run: |
+        echo " Cleaning up temporary files..."
+        rm -f state_resources.txt pool_details.txt || true
+        echo " Cleanup completed"
+        
+    - name: Workflow Summary
+      if: always()
+      run: |
+        echo "##  Ensure Preview Pool Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- **Pool was enabled**: ${{ steps.current-state.outputs.pool-enabled }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Workflow status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+        
+        if [ "${{ steps.current-state.outputs.pool-enabled }}" == "false" ] && [ "${{ job.status }}" == "success" ]; then
+          echo "- **Action taken**:  Successfully enabled preview pool (~$14/month cost)" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ steps.current-state.outputs.pool-enabled }}" == "true" ]; then
+          echo "- **Action taken**:  No action needed - pool already enabled" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- **Action taken**:  Failed to enable preview pool" >> $GITHUB_STEP_SUMMARY
+        fi
+        
+    - name: Notify Success
+      if: success() && steps.current-state.outputs.pool-enabled == 'false'
+      run: |
+        echo " Preview pool has been successfully enabled"
+        echo "Preview pool will be available in a few minutes"
+        
+    - name: Notify Failure
+      if: failure()
+      run: |
+        echo " Failed to enable preview pool"
+        echo "Please check the logs and try again"

--- a/.github/workflows/reconcile_preview_pool.yml
+++ b/.github/workflows/reconcile_preview_pool.yml
@@ -1,0 +1,232 @@
+name: Reconcile Preview Pool
+
+on:
+  schedule:
+    # Run every hour at minute 0
+    - cron: '0 * * * *'
+  workflow_dispatch: # Allow manual trigger
+
+# Prevent concurrent runs with any preview pool operations to avoid state conflicts
+concurrency:
+  group: terraform-preview-pool-operations
+  cancel-in-progress: false
+
+jobs:
+  reconcile-preview-pool:
+    name: Auto-manage Preview Pool
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
+    - name: Check Open PRs in App Repository
+      id: check-prs
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          try {
+            // Get open PRs from  repository
+            const { data: prs } = await github.rest.pulls.list({
+              owner: 'jalantechnologies',
+              repo: 'flask-react-template',
+              state: 'open'
+            });
+            
+            // Filter out draft PRs
+            const nonDraftPrs = prs.filter(pr => !pr.draft);
+            const prCount = nonDraftPrs.length;
+            
+            console.log(`Found ${prCount} open non-draft PRs in flask-react-template`);
+            
+            // Log PR details for debugging
+            nonDraftPrs.forEach(pr => {
+              console.log(`- PR #${pr.number}: ${pr.title} (${pr.user.login})`);
+            });
+            
+            // Set outputs
+            core.setOutput('pr-count', prCount);
+            core.setOutput('needs-preview-pool', prCount > 0 ? 'true' : 'false');
+            
+            return {
+              prCount: prCount,
+              needsPreviewPool: prCount > 0
+            };
+          } catch (error) {
+            console.error('Error checking PRs:', error);
+            core.setFailed(`Failed to check PRs: ${error.message}`);
+          }
+          
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+        terraform_wrapper: false  # Disable wrapper for better error handling
+        
+    - name: Terraform Init
+      run: |
+        echo "🔧 Initializing Terraform..."
+        terraform init
+        echo "Terraform initialization completed"
+        
+    - name: Terraform Validate
+      run: |
+        echo " Validating Terraform configuration..."
+        terraform validate
+        echo " Terraform configuration is valid"
+      
+    - name: Detect current infrastructure state
+      id: current-status
+      shell: bash
+      run: |
+        set +e  # Explicitly disable exit on error
+        echo " Detecting current preview pool state from Terraform Cloud state..."
+        
+        # Use Terraform Cloud API to get current state
+        echo " Fetching current state from Terraform Cloud backend..."
+        
+        # Use terraform state list to check if preview pool resource exists
+        echo "🔍 Fetching current Terraform state..."
+        if terraform state list > state_resources.txt 2>/dev/null; then
+          echo " Successfully retrieved Terraform state"
+          echo " Current resources in state:"
+          cat state_resources.txt
+        else
+          echo " Could not retrieve Terraform state - assuming no resources exist"
+          touch state_resources.txt  # Create empty file for consistent processing
+        fi
+        
+        # Check if preview pool resource exists in state (handle both indexed and non-indexed)
+        if grep -q "module.digital_ocean.digitalocean_kubernetes_node_pool.do_cluster_staging_pool" state_resources.txt; then
+          echo " Preview pool resource found in state - checking if it's actually running..."
+          
+          # Try to get the exact resource name from state list
+          RESOURCE_NAME=$(grep "module.digital_ocean.digitalocean_kubernetes_node_pool.do_cluster_staging_pool" state_resources.txt | head -1)
+          echo " Found resource: $RESOURCE_NAME"
+          
+          # Get detailed resource information using the exact name from state
+          echo " Getting detailed resource information..."
+          if terraform state show "$RESOURCE_NAME" > pool_details.txt 2>/dev/null; then
+            echo " Successfully retrieved resource details"
+          else
+            echo " Could not retrieve resource details - assuming resource needs attention"
+            touch pool_details.txt  # Create empty file for consistent processing
+          fi
+          
+          if [ -s pool_details.txt ]; then
+            # Extract key resource attributes
+            POOL_NAME=$(grep -E "name\s*=" pool_details.txt | head -1 | sed 's/.*= "//' | sed 's/".*//')
+            POOL_ID=$(grep -E "id\s*=" pool_details.txt | head -1 | sed 's/.*= "//' | sed 's/".*//')
+            NODE_COUNT=$(grep -E "actual_node_count\s*=" pool_details.txt | head -1 | sed 's/.*= //' | sed 's/[^0-9]//g')
+            
+            echo " Resource details:"
+            echo "  - Pool Name: $POOL_NAME"
+            echo "  - Pool ID: $POOL_ID"
+            echo "  - Active Nodes: $NODE_COUNT"
+            
+            # Check if it's the staging pool and has active nodes
+            if [[ "$POOL_NAME" == *"staging-pool"* ]] && [[ "$NODE_COUNT" -gt 0 ]]; then
+              echo " Preview pool is currently ENABLED"
+              echo "   - Staging pool '$POOL_NAME' is running with $NODE_COUNT active nodes"
+              echo "currently-enabled=1" >> $GITHUB_OUTPUT
+            elif [[ "$POOL_NAME" == *"staging-pool"* ]] && [[ "$NODE_COUNT" -eq 0 ]]; then
+              echo " Staging pool exists but has 0 active nodes - considering DISABLED"
+              echo "currently-enabled=0" >> $GITHUB_OUTPUT
+            else
+              echo " Resource exists but not a staging pool (name: $POOL_NAME)"
+              echo "currently-enabled=0" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo " Preview pool resource in state but no details - assuming disabled"
+            echo "currently-enabled=0" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo " Preview pool resource NOT found in state"
+          echo " Preview pool is currently DISABLED (no resource in state)"
+          echo "currently-enabled=0" >> $GITHUB_OUTPUT
+        fi
+        
+        echo " State-based detection completed"
+        
+    - name: Show Plan Before Enabling
+      if: steps.check-prs.outputs.needs-preview-pool == 'true' && steps.current-status.outputs.currently-enabled == '0'
+      run: |
+        echo " Terraform plan to enable preview pool:"
+        terraform plan -var="enable_preview_pool=true" -no-color
+        
+    - name: Enable Preview Pool
+      if: steps.check-prs.outputs.needs-preview-pool == 'true' && steps.current-status.outputs.currently-enabled == '0'
+      run: |
+        echo " Enabling preview pool - found ${{ steps.check-prs.outputs.pr-count }} open PRs"
+        
+        terraform apply -auto-approve \
+          -var="enable_preview_pool=true"
+        
+        if [ $? -eq 0 ]; then
+          echo " Preview pool successfully enabled"
+          echo " Preview environment is now available for PR testing"
+        else
+          echo " Failed to enable preview pool"
+          exit 1
+        fi
+          
+    - name: Show Plan Before Disabling
+      if: steps.check-prs.outputs.needs-preview-pool == 'false' && steps.current-status.outputs.currently-enabled == '1'
+      run: |
+        echo " Terraform plan to disable preview pool:"
+        terraform plan -var="enable_preview_pool=false" -no-color
+        
+    - name: Disable Preview Pool
+      if: steps.check-prs.outputs.needs-preview-pool == 'false' && steps.current-status.outputs.currently-enabled == '1'
+      run: |
+        echo " Disabling preview pool - no open PRs found"
+      
+        
+        terraform apply -auto-approve \
+          -var="enable_preview_pool=false"
+        
+        if [ $? -eq 0 ]; then
+          echo " Preview pool successfully disabled"
+          echo " Cost savings activated - preview resources destroyed"
+        else
+          echo " Failed to disable preview pool"
+          exit 1
+        fi
+          
+    - name: No Action Needed
+      if: (steps.check-prs.outputs.needs-preview-pool == 'true' && steps.current-status.outputs.currently-enabled == '1') || (steps.check-prs.outputs.needs-preview-pool == 'false' && steps.current-status.outputs.currently-enabled == '0')
+      run: |
+        echo " Infrastructure state matches requirements - no action needed"
+        if [ "${{ steps.check-prs.outputs.needs-preview-pool }}" == "true" ]; then
+          echo " Preview pool already enabled for ${{ steps.check-prs.outputs.pr-count }} open PRs"
+          echo " Preview environment is ready for development"
+        else
+          echo " Preview pool already disabled - no open PRs detected"
+          echo " Cost optimization is active - no unnecessary resources running"
+        fi
+        
+    - name: Cleanup Temporary Files
+      if: always()
+      run: |
+        echo " Cleaning up temporary files..."
+        rm -f state_resources.txt pool_details.txt || true
+        echo " Cleanup completed"
+        
+    - name: Workflow Summary
+      if: always()
+      run: |
+        echo "##  Reconciliation Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- **Repository**: jalantechnologies/flask-react-template" >> $GITHUB_STEP_SUMMARY
+        echo "- **Open PRs**: ${{ steps.check-prs.outputs.pr-count }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Preview pool needed**: ${{ steps.check-prs.outputs.needs-preview-pool }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Currently enabled**: ${{ steps.current-status.outputs.currently-enabled }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Workflow status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+        
+        if [ "${{ steps.check-prs.outputs.needs-preview-pool }}" == "true" ] && [ "${{ steps.current-status.outputs.currently-enabled }}" == "0" ]; then
+          echo "- **Action taken**:  Enabled preview pool" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ steps.check-prs.outputs.needs-preview-pool }}" == "false" ] && [ "${{ steps.current-status.outputs.currently-enabled }}" == "1" ]; then
+          echo "- **Action taken**:  Disabled preview pool " >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- **Action taken**:  No change needed" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   cloud {
     organization = "jalantechnologies"
     workspaces {
-      name = "platform-do-cluster-tf"
+      name = "platform-digitalocean-tf"
     }
   }
 }
@@ -39,10 +39,12 @@ provider "kubectl" {
 }
 
 module "digital_ocean" {
-  source             = "./modules/digital-ocean"
-  do_cluster_name    = var.do_cluster_name
-  do_alert_email     = var.do_alert_email
-  do_cluster_version = var.do_cluster_version
+  source               = "./modules/digital-ocean"
+  do_cluster_name      = var.do_cluster_name
+  do_alert_email       = var.do_alert_email
+  do_cluster_version   = var.do_cluster_version
+  enable_preview_pool  = var.enable_preview_pool
+  preview_node_size    = var.preview_node_size
 }
 
 module "kubernetes" {

--- a/modules/digital-ocean/cluster.tf
+++ b/modules/digital-ocean/cluster.tf
@@ -19,6 +19,18 @@ variable "do_cluster_node_size" {
   default     = "s-2vcpu-4gb"
 }
 
+variable "enable_preview_pool" {
+  description = "Whether to enable the preview node pool for PR environments"
+  type        = bool
+  default     = false
+}
+
+variable "preview_node_size" {
+  description = "The slug identifier for the type of Droplet to be used in the preview node pool"
+  type        = string
+  default     = "s-2vcpu-4gb"
+}
+
 resource "digitalocean_kubernetes_cluster" "do_cluster" {
   name    = var.do_cluster_name
   region  = var.do_cluster_region
@@ -42,9 +54,10 @@ resource "digitalocean_kubernetes_cluster" "do_cluster" {
 }
 
 resource "digitalocean_kubernetes_node_pool" "do_cluster_staging_pool" {
+  count      = var.enable_preview_pool ? 1 : 0
   name       = "${var.do_cluster_name}-staging-pool"
   cluster_id = digitalocean_kubernetes_cluster.do_cluster.id
-  size       = var.do_cluster_node_size
+  size       = var.preview_node_size
   auto_scale = true
   min_nodes  = 1
   max_nodes  = 2

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,15 @@ variable "do_cluster_version" {
   # list is available at https://slugs.do-api.dev/ on "Kubernetes Versions"
   description = "The slug identifier for the version of Kubernetes used for the cluster"
 }
+
+variable "enable_preview_pool" {
+  description = "Whether to enable the preview node pool for PR environments"
+  type        = bool
+  default     = false
+}
+
+variable "preview_node_size" {
+  description = "The slug identifier for the type of Droplet to be used in the preview node pool"
+  type        = string
+  default     = "s-2vcpu-4gb"
+}


### PR DESCRIPTION
**Why these changes were required**

Previously, the preview node pool was running continuously, even when there were no open PRs on GitHub. This was causing unnecessary charges on DigitalOcean.

**Changes implemented**

**1)Preview Pool Auto-Toggle**

- The preview node pool is now automatically destroyed if there are no open PRs on GitHub for an hour, reducing unnecessary costs.
- If a PR is opened, the preview pool can be recreated either automatically (via cron) or manually using the workflow.

**2)Workflow Concurrency**

- Only one preview pool workflow can run at a time.
- Subsequent workflow triggers are queued until the currently running workflow completes, ensuring proper Terraform state management.


**Manual Testing Conducted**

**1) Open PR with preview pool enabled**
- Opened a PR on GitHub.
- Preview pool was already running in DigitalOcean.
- Workflow detected the open PR and found the pool enabled.
- Creation step was skipped with a message: “Preview pool is already running.”
<img width="1820" height="739" alt="Screenshot 2025-09-26 113216" src="https://github.com/user-attachments/assets/e2cc28f1-6039-4f5d-bd98-e62a971ce1fe" />
<img width="1885" height="475" alt="Screenshot 2025-09-26 113505" src="https://github.com/user-attachments/assets/9a9dc3b3-7a6c-4e62-9c4b-345f8d0eff80" />



**2) Open PR with preview pool disabled**

- Opened a PR on GitHub.
- Preview pool was not running.
- Workflow detected the open PR and found the pool disabled.
- Pool creation was triggered successfully.
<img width="1123" height="352" alt="Screenshot 2025-09-26 113946" src="https://github.com/user-attachments/assets/1d0433fe-5284-4653-9a29-5a85b3960efc" />

<img width="1363" height="542" alt="Screenshot 2025-09-26 114011" src="https://github.com/user-attachments/assets/af22a5a1-5e78-468f-b6e6-a0d6a1a51017" />

<img width="1272" height="603" alt="Screenshot 2025-09-26 114045" src="https://github.com/user-attachments/assets/6c079f1b-0a6b-4af1-a14c-ddabc31915e2" />


**3) Closed PR with preview pool enabled**

- Closed the PR.
- Preview pool was running in DigitalOcean.
- Workflow detected no open PRs and found the pool enabled.
- Pool destruction was triggered automatically.

<img width="1346" height="536" alt="Screenshot 2025-09-26 114609" src="https://github.com/user-attachments/assets/3f8a506e-84cb-4690-ae14-26e019994926" />

<img width="1360" height="527" alt="Screenshot 2025-09-26 114634" src="https://github.com/user-attachments/assets/f2296d30-af71-4949-9abb-851e63a3bf60" />

<img width="1388" height="515" alt="Screenshot 2025-09-26 114706" src="https://github.com/user-attachments/assets/f2f72202-3e72-4e27-88e4-de734d3cc6d2" />


**4) Closed PR with preview pool disabled**

- Closed the PR.
- Preview pool was already disabled.
- Workflow detected no open PRs and skipped the destruction step with a message: “Preview pool is already disabled.”

<img width="1238" height="538" alt="Screenshot 2025-09-26 114904" src="https://github.com/user-attachments/assets/2481c304-caee-4ba7-80de-581eec0e7d0a" />

<img width="1340" height="294" alt="Screenshot 2025-09-26 114925" src="https://github.com/user-attachments/assets/3b0f4666-adda-4073-be6f-67734a0a6595" />

<img width="1050" height="532" alt="Screenshot 2025-09-26 114948" src="https://github.com/user-attachments/assets/814d9017-b93d-45a5-a43b-96887d509d4a" />


**5) Concurrency Testing**

- Triggered multiple preview pool workflows in quick succession.
- First workflow ran immediately.
- Second workflow was queued and executed only after the first workflow completed, preventing state conflicts.

<img width="1905" height="853" alt="Screenshot 2025-09-26 115109" src="https://github.com/user-attachments/assets/f98bc5b1-5649-412b-b491-5360ca2fd047" />

<img width="1389" height="309" alt="Screenshot 2025-09-26 115128" src="https://github.com/user-attachments/assets/6d8a9a7e-00de-425f-b018-326eddbea08e" />

