### PR TITLE
feat: Automate MongoDB Atlas provisioning via Terraform

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,43 +2,49 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/digitalocean/digitalocean" {
-  version     = "2.25.2"
+  version     = "2.76.0"
   constraints = "~> 2.0"
   hashes = [
-    "h1:hJ2aJzN7HDiSnQDrxvKurs6ox5Do5tIjseW2Pgqjarg=",
-    "zh:0accb40afb05425f20ff93426c69fa9585fd269f5a0caff9e03173ca3a0f66f0",
-    "zh:0e389b5ebfce42a9a1c78b576acffa6d4f1cfa421810537e6e096a254ff3fec8",
-    "zh:12441f028af172a823b452bb017721d7bf2f6f14e343ac90f361c7bb73ff0874",
-    "zh:18e04874d833d014617ee94971b8ef4638931a3ee7c572f86ee816b74911bcb5",
-    "zh:4e728375e24fdc37e791b3f234c991da342dbad8e1bd878531dd45ab6710c4fe",
-    "zh:4f76bea793d71ae85c72275bd1a5d28ce72afbb41e6cf51cc74d19a470b2c4dc",
-    "zh:588fd686e257b9d989427106e16b7d35a805cf6c1f532dca8fd61c09f19cc95a",
-    "zh:5b433b49869a45d96b95e921dd3cc713471dfa78157fe6f89f09d41c689256c2",
-    "zh:5de660180ab655b64e579564ec5f60f63d7c6633f47dfe4c8ac5a6718d19b5ea",
-    "zh:6395f4d9995f525469d88825f56c88f46b3466db26a3962a645c9a2e65e60dad",
-    "zh:7b04b9ca110f3876000616f9f3f046a974a20db93583786f26dccf10ed9372cf",
-    "zh:81b02a7247a0142075315cdbccd41138c01ed3327036c6b3b417859b06fdac0d",
-    "zh:99e4cf8818eed4e0516a939658ae89a8eefeb4dd9d49303b47b28dc844f983ac",
-    "zh:a85ddbfc6db67508a64c95edd333132efbc40ab7b4d6266023750dc7756f6bec",
-    "zh:b7e9ee035192e2f4d8db11d33e0dabd1969135901bae52d96001fce5f2a4dce8",
-    "zh:ec5d133c03319ec103c80d954be31dd673f44e9c93ec9ed951576e110549b59f",
+    "h1:oHT8bWwX73s/Fd7e/w/mBNONdo5msrSNKiPTmHnVVto=",
+    "zh:1841b45a8fc8f10e8470c75f511d7f4b8e67e2630f89888104844a46cb31173e",
+    "zh:2a99ad56cd732ff75a70bcd8c9df9218791af9c1feb870aa5dab5678cbb8ead6",
+    "zh:32b4a4500789ed133751e2360bcfa1a3518277c101e977633c3d14dc55ba74df",
+    "zh:49788e4de1e5af1edfb2287e7a9771103e38ad2803cf527dd263104f4c3b7eff",
+    "zh:61002c7ae9fc1e96a377c6c1b365a99915e16b4fdb3b4fc82561083a2dc347d1",
+    "zh:667381d6bd5c1015f570a42bd59e88ce3d04e65dc3c3f57f1788ae5bd94a41bc",
+    "zh:6c4de4bb01581439cc35bf2a3d143f428cb0c0a8e13a78f23531faee6abf7dbe",
+    "zh:70424482fa6f736f9dc8fa226b92cef4d4565eea4096b7d7c7ffa735b8286cbb",
+    "zh:72a235d2cf6c1313601efc2ba816053773d76bff658aa3012789905e4894d84a",
+    "zh:7bbedeb1d86caee92e91ac7ad3fb0ceadb73e4a4bce8dd5336b71beba4cf5395",
+    "zh:8660644ab50f9e42f014bd30ad2704a116d85bd222da291ddbd75eaf79f4c643",
+    "zh:b5fa2f4341d723bc58b9d7bee4baea4d4d04ca797f99ceeaf21d95b023ea4eea",
+    "zh:bd1d161f9d7058e74876392da2dcc04ccbb12e3250b9884dec663816cb87f67e",
+    "zh:c1938a1b11f5b08f9f5901dc5fa74608edbc0956272ab571050f15f8fd6aa279",
+    "zh:e30bad56d72e160d87dfa2f36bd897479f6339e6c2b0a188b9030421326857ea",
+    "zh:f9b4ed69f1cdbdf827252d0db9ae2643117953d2faefafe8148c74e1d0c0cb5c",
   ]
 }
 
 provider "registry.terraform.io/gavinbunney/kubectl" {
-  version     = "1.14.0"
+  version     = "1.19.0"
   constraints = ">= 1.7.0"
   hashes = [
-    "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
-    "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
-    "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
-    "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
-    "zh:39f1a0aa1d589a7e815b62b5aa11041040903b061672c4cfc7de38622866cbc4",
-    "zh:428d3a321043b78e23c91a8d641f2d08d6b97f74c195c654f04d2c455e017de5",
-    "zh:4baf5b1de2dfe9968cc0f57fd4be5a741deb5b34ee0989519267697af5f3eee5",
-    "zh:6131a927f9dffa014ab5ca5364ac965fe9b19830d2bbf916a5b2865b956fdfcf",
-    "zh:c62e0c9fd052cbf68c5c2612af4f6408c61c7e37b615dc347918d2442dd05e93",
-    "zh:f0beffd7ce78f49ead612e4b1aefb7cb6a461d040428f514f4f9cc4e5698ac65",
+    "h1:9QkxPjp0x5FZFfJbE+B7hBOoads9gmdfj9aYu5N4Sfc=",
+    "zh:1dec8766336ac5b00b3d8f62e3fff6390f5f60699c9299920fc9861a76f00c71",
+    "zh:43f101b56b58d7fead6a511728b4e09f7c41dc2e3963f59cf1c146c4767c6cb7",
+    "zh:4c4fbaa44f60e722f25cc05ee11dfaec282893c5c0ffa27bc88c382dbfbaa35c",
+    "zh:51dd23238b7b677b8a1abbfcc7deec53ffa5ec79e58e3b54d6be334d3d01bc0e",
+    "zh:5afc2ebc75b9d708730dbabdc8f94dd559d7f2fc5a31c5101358bd8d016916ba",
+    "zh:6be6e72d4663776390a82a37e34f7359f726d0120df622f4a2b46619338a168e",
+    "zh:72642d5fcf1e3febb6e5d4ae7b592bb9ff3cb220af041dbda893588e4bf30c0c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1da03e3239867b35812ee031a1060fed6e8d8e458e2eaca48b5dd51b35f56f7",
+    "zh:b98b6a6728fe277fcd133bdfa7237bd733eae233f09653523f14460f608f8ba2",
+    "zh:bb8b071d0437f4767695c6158a3cb70df9f52e377c67019971d888b99147511f",
+    "zh:dc89ce4b63bfef708ec29c17e85ad0232a1794336dc54dd88c3ba0b77e764f71",
+    "zh:dd7dd18f1f8218c6cd19592288fde32dccc743cde05b9feeb2883f37c2ff4b4e",
+    "zh:ec4bd5ab3872dedb39fe528319b4bba609306e12ee90971495f109e142d66310",
+    "zh:f610ead42f724c82f5463e0e71fa735a11ffb6101880665d93f48b4a67b9ad82",
   ]
 }
 
@@ -47,6 +53,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.5.1"
   hashes = [
     "h1:9yMFsXyHAo+mUuMKczNSw44HcZaf1JkMqgOUgJF1dXs=",
+    "h1:NasRPC0qqlpGqcF3dsSoOFu7uc5hM+zJm+okd8FgrnQ=",
     "zh:140b9748f0ad193a20d69e59d672f3c4eda8a56cede56a92f931bd3af020e2e9",
     "zh:17ae319466ed6538ad49e011998bb86565fe0e97bc8b9ad7c8dda46a20f90669",
     "zh:3a8bd723c21ba70e19f0395ed7096fc8e08bfc23366f1c3f06a9107eb37c572c",
@@ -67,6 +74,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.11.0"
   hashes = [
     "h1:lSh/Q5vX73hHL80TtGn2Vrv1UYLzlIRjC+xaCijY4ew=",
+    "h1:pJiAJwZKUaoAJ4x+3ONJkwEVkjrwGROCGFgj7noPO58=",
     "zh:143a19dd0ea3b07fc5e3d9231f3c2d01f92894385c98a67327de74c76c715843",
     "zh:1fc757d209e09c3cf7848e4274daa32408c07743698fbed10ee52a4a479b62b6",
     "zh:22dfebd0685749c51a8f765d51a1090a259778960ac1cd4f32021a325b2b9b72",
@@ -79,5 +87,47 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
     "zh:88e418118cd5afbdec4984944c7ab36950bf48e8d3e09e090232e55eecfb470b",
     "zh:9cef159377bf23fa331f8724fdc6ce27ad39a217a4bae6df3b1ca408fc643da6",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}
+
+provider "registry.terraform.io/mongodb/mongodbatlas" {
+  version     = "1.41.1"
+  constraints = "~> 1.20"
+  hashes = [
+    "h1:cBmoserS0XcXZuqJu/VVyQaDyBLRSPwgq32yJRdq3l0=",
+    "zh:07a68922c8a0aca320b60fbcf66e5c95bf46b0506a79eb44aab4f92f0b34df02",
+    "zh:135917d9624ab2407b4ff95f920f46ab912ed0e1eae8254baca2e278ec6fe701",
+    "zh:162e5fa542d5934ebf2756f09f425145e6532dbc1a40cfa8bc4cc0427c960ac9",
+    "zh:1b5959aecdb8ee60eae5a1be3c3331f4290e60b2cda638a2b1b150a773ba4a8a",
+    "zh:31036567d0fd0225c2f3e8029a2b4851c0b1ce3cb8af9c0c8829e580cd004ff5",
+    "zh:34068989345ac1b211ca1d3e80e2ea5260c25902d47e2db4e11b14da2dc81c74",
+    "zh:4d15bdb871cd31439766402bd3863175fd09176031ee93804bc8934030b466ac",
+    "zh:55ef4220110bbac41057d425ba2fb51cc4a4d58922257fe868e153aeb169528c",
+    "zh:7eb3eb0b999faadd5569841b02f94e308641b493b839bb6a76fbf1354e6966d0",
+    "zh:ec7048c4f52caf5ecff9820f2ac888bc3f715d0988112581ec167b59e6a17360",
+    "zh:f38cb6ee08c5b81aaebd6a0e5424e348a6f292144da3f4b0352f9023f2c9f807",
+    "zh:f46c68678050c4a524c82daddc30f46f7a34f18d495dc49c2149055f884c52ef",
+    "zh:f4e943ba43e7ed7d2f1162b903bd26cc76409f8b9433436dbeac1ca1ff3c4b24",
+    "zh:f8609443db65c86d73124f3ca484e6d14c80731708e333447cc4f9ca33bf2467",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This template can optionally provision MongoDB Atlas resources through Terraform
 - Create Atlas free/shared cluster (defaults to `M0`)
 - Create application database user
 - Create IP access list entries
-- Output connection string for Doppler or app env vars
+- Output full connection URI with credentials for Doppler
 
 Set these variables and enable Atlas provisioning:
 
@@ -42,13 +42,10 @@ Optional defaults:
 
 ```hcl
 atlas_project_name       = "platform-apps"
-atlas_cluster_name       = "shared-free-cluster"
+atlas_cluster_name       = "Cluster0"
 atlas_instance_size_name = "M0"
-atlas_region             = "US_EAST_1"
+atlas_region             = "AP_SOUTH_1"
 atlas_access_list_cidrs  = ["0.0.0.0/0"]
 ```
 
-Sensitive outputs:
-
-- `atlas_connection_uri`
-- `atlas_database_user_password`
+After apply, use `terraform output atlas_connection_uri` (sensitive) and add it to Doppler for app env vars.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,37 @@ This project is a template for setting up Kubernetes cluster on DigitalOcean.
 ```bash
 terraform refresh -target=module.digital_ocean.digitalocean_kubernetes_cluster.do_cluster
 ```
+
+## MongoDB Atlas Automation
+
+This template can optionally provision MongoDB Atlas resources through Terraform.
+
+- Create Atlas project
+- Create Atlas free/shared cluster (defaults to `M0`)
+- Create application database user
+- Create IP access list entries
+- Output connection string for Doppler or app env vars
+
+Set these variables and enable Atlas provisioning:
+
+```hcl
+atlas_enabled     = true
+atlas_org_id      = "YOUR_ATLAS_ORG_ID"
+atlas_public_key  = "YOUR_ATLAS_PUBLIC_KEY"
+atlas_private_key = "YOUR_ATLAS_PRIVATE_KEY"
+```
+
+Optional defaults:
+
+```hcl
+atlas_project_name       = "platform-apps"
+atlas_cluster_name       = "shared-free-cluster"
+atlas_instance_size_name = "M0"
+atlas_region             = "US_EAST_1"
+atlas_access_list_cidrs  = ["0.0.0.0/0"]
+```
+
+Sensitive outputs:
+
+- `atlas_connection_uri`
+- `atlas_database_user_password`

--- a/main.tf
+++ b/main.tf
@@ -61,12 +61,12 @@ module "atlas_mongodb" {
   count  = var.atlas_enabled ? 1 : 0
   source = "./modules/mongodb-atlas"
 
-  atlas_org_id                = var.atlas_org_id
-  atlas_project_name          = var.atlas_project_name
-  atlas_cluster_name          = var.atlas_cluster_name
-  atlas_provider_name         = var.atlas_provider_name
-  atlas_backing_provider_name = var.atlas_backing_provider_name
-  atlas_region                = var.atlas_region
+  atlas_org_id                 = var.atlas_org_id
+  atlas_project_name           = var.atlas_project_name
+  atlas_cluster_name           = var.atlas_cluster_name
+  atlas_provider_name          = var.atlas_provider_name
+  atlas_backing_provider_name  = var.atlas_backing_provider_name
+  atlas_region                 = var.atlas_region
   atlas_instance_size_name     = var.atlas_instance_size_name
   atlas_mongodb_major_version  = var.atlas_mongodb_major_version
   atlas_database_name          = var.atlas_database_name

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,11 @@ provider "digitalocean" {
   token = var.do_token
 }
 
+provider "mongodbatlas" {
+  public_key  = var.atlas_public_key
+  private_key = var.atlas_private_key
+}
+
 provider "kubernetes" {
   host                   = module.digital_ocean.do_cluster_host
   token                  = module.digital_ocean.do_cluster_token
@@ -56,18 +61,16 @@ module "atlas_mongodb" {
   count  = var.atlas_enabled ? 1 : 0
   source = "./modules/mongodb-atlas"
 
-  atlas_org_id                 = var.atlas_org_id
-  atlas_public_key             = var.atlas_public_key
-  atlas_private_key            = var.atlas_private_key
-  atlas_project_name           = var.atlas_project_name
-  atlas_cluster_name           = var.atlas_cluster_name
-  atlas_provider_name          = var.atlas_provider_name
-  atlas_backing_provider_name  = var.atlas_backing_provider_name
-  atlas_region                 = var.atlas_region
-  atlas_instance_size_name     = var.atlas_instance_size_name
-  atlas_mongodb_major_version  = var.atlas_mongodb_major_version
-  atlas_database_name          = var.atlas_database_name
-  atlas_database_username      = var.atlas_database_username
+  atlas_org_id                = var.atlas_org_id
+  atlas_project_name          = var.atlas_project_name
+  atlas_cluster_name          = var.atlas_cluster_name
+  atlas_provider_name         = var.atlas_provider_name
+  atlas_backing_provider_name = var.atlas_backing_provider_name
+  atlas_region                = var.atlas_region
+  atlas_instance_size_name    = var.atlas_instance_size_name
+  atlas_mongodb_major_version = var.atlas_mongodb_major_version
+  atlas_database_name         = var.atlas_database_name
+  atlas_database_username     = var.atlas_database_username
   atlas_database_user_password = var.atlas_database_user_password
   atlas_access_list_cidrs      = var.atlas_access_list_cidrs
 }

--- a/main.tf
+++ b/main.tf
@@ -51,3 +51,23 @@ module "kubernetes" {
   cluster_issuer_email = var.cluster_issuer_email
   cluster_issuer_name  = "letsencrypt-prod"
 }
+
+module "atlas_mongodb" {
+  count  = var.atlas_enabled ? 1 : 0
+  source = "./modules/mongodb-atlas"
+
+  atlas_org_id                 = var.atlas_org_id
+  atlas_public_key             = var.atlas_public_key
+  atlas_private_key            = var.atlas_private_key
+  atlas_project_name           = var.atlas_project_name
+  atlas_cluster_name           = var.atlas_cluster_name
+  atlas_provider_name          = var.atlas_provider_name
+  atlas_backing_provider_name  = var.atlas_backing_provider_name
+  atlas_region                 = var.atlas_region
+  atlas_instance_size_name     = var.atlas_instance_size_name
+  atlas_mongodb_major_version  = var.atlas_mongodb_major_version
+  atlas_database_name          = var.atlas_database_name
+  atlas_database_username      = var.atlas_database_username
+  atlas_database_user_password = var.atlas_database_user_password
+  atlas_access_list_cidrs      = var.atlas_access_list_cidrs
+}

--- a/main.tf
+++ b/main.tf
@@ -67,10 +67,10 @@ module "atlas_mongodb" {
   atlas_provider_name         = var.atlas_provider_name
   atlas_backing_provider_name = var.atlas_backing_provider_name
   atlas_region                = var.atlas_region
-  atlas_instance_size_name    = var.atlas_instance_size_name
-  atlas_mongodb_major_version = var.atlas_mongodb_major_version
-  atlas_database_name         = var.atlas_database_name
-  atlas_database_username     = var.atlas_database_username
+  atlas_instance_size_name     = var.atlas_instance_size_name
+  atlas_mongodb_major_version  = var.atlas_mongodb_major_version
+  atlas_database_name          = var.atlas_database_name
+  atlas_database_username      = var.atlas_database_username
   atlas_database_user_password = var.atlas_database_user_password
   atlas_access_list_cidrs      = var.atlas_access_list_cidrs
 }

--- a/modules/kubernetes/cert-manager.tf
+++ b/modules/kubernetes/cert-manager.tf
@@ -24,7 +24,7 @@ resource "helm_release" "cert_manager" {
 resource "kubectl_manifest" "cluster_issuer" {
   depends_on      = [helm_release.cert_manager]
   validate_schema = false
-  yaml_body       = templatefile("${path.module}/specs/cert-manager-issuer-values.yaml", {
+  yaml_body = templatefile("${path.module}/specs/cert-manager-issuer-values.yaml", {
     cluster_issuer_name  = var.cluster_issuer_name
     cluster_issuer_email = var.cluster_issuer_email
   })

--- a/modules/mongodb-atlas/main.tf
+++ b/modules/mongodb-atlas/main.tf
@@ -1,0 +1,54 @@
+provider "mongodbatlas" {
+  public_key  = var.atlas_public_key
+  private_key = var.atlas_private_key
+}
+
+resource "mongodbatlas_project" "this" {
+  name   = var.atlas_project_name
+  org_id = var.atlas_org_id
+}
+
+resource "mongodbatlas_cluster" "this" {
+  project_id                  = mongodbatlas_project.this.id
+  name                        = var.atlas_cluster_name
+  cluster_type                = "REPLICASET"
+  provider_name               = var.atlas_provider_name
+  backing_provider_name       = var.atlas_backing_provider_name
+  provider_region_name        = var.atlas_region
+  provider_instance_size_name = var.atlas_instance_size_name
+  mongodb_major_version       = var.atlas_mongodb_major_version
+}
+
+resource "random_password" "atlas_database_user_password" {
+  count   = var.atlas_database_user_password == null ? 1 : 0
+  length  = 32
+  special = true
+}
+
+locals {
+  effective_database_user_password = var.atlas_database_user_password != null ? var.atlas_database_user_password : random_password.atlas_database_user_password[0].result
+}
+
+resource "mongodbatlas_database_user" "app" {
+  username           = var.atlas_database_username
+  password           = local.effective_database_user_password
+  project_id         = mongodbatlas_project.this.id
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "readWrite"
+    database_name = var.atlas_database_name
+  }
+
+  scopes {
+    name = mongodbatlas_cluster.this.name
+    type = "CLUSTER"
+  }
+}
+
+resource "mongodbatlas_project_ip_access_list" "this" {
+  for_each   = toset(var.atlas_access_list_cidrs)
+  project_id = mongodbatlas_project.this.id
+  cidr_block = each.value
+  comment    = "Managed by Terraform"
+}

--- a/modules/mongodb-atlas/main.tf
+++ b/modules/mongodb-atlas/main.tf
@@ -11,7 +11,7 @@ resource "mongodbatlas_cluster" "this" {
   backing_provider_name       = var.atlas_backing_provider_name
   provider_region_name        = var.atlas_region
   provider_instance_size_name = var.atlas_instance_size_name
-  mongodb_major_version       = var.atlas_mongodb_major_version
+  mongo_db_major_version      = var.atlas_mongodb_major_version
 }
 
 resource "random_password" "atlas_database_user_password" {

--- a/modules/mongodb-atlas/main.tf
+++ b/modules/mongodb-atlas/main.tf
@@ -1,8 +1,3 @@
-provider "mongodbatlas" {
-  public_key  = var.atlas_public_key
-  private_key = var.atlas_private_key
-}
-
 resource "mongodbatlas_project" "this" {
   name   = var.atlas_project_name
   org_id = var.atlas_org_id

--- a/modules/mongodb-atlas/outputs.tf
+++ b/modules/mongodb-atlas/outputs.tf
@@ -1,0 +1,31 @@
+output "atlas_project_id" {
+  description = "MongoDB Atlas project ID"
+  value       = mongodbatlas_project.this.id
+}
+
+output "atlas_cluster_name" {
+  description = "MongoDB Atlas cluster name"
+  value       = mongodbatlas_cluster.this.name
+}
+
+output "atlas_connection_uri" {
+  description = "Connection string including credentials"
+  value       = "mongodb+srv://${var.atlas_database_username}:${urlencode(local.effective_database_user_password)}@${replace(mongodbatlas_cluster.this.connection_strings[0].standard_srv, "mongodb+srv://", "")}/${var.atlas_database_name}?retryWrites=true&w=majority"
+  sensitive   = true
+}
+
+output "atlas_connection_uri_srv" {
+  description = "SRV connection string without credentials"
+  value       = mongodbatlas_cluster.this.connection_strings[0].standard_srv
+}
+
+output "atlas_database_username" {
+  description = "MongoDB Atlas database user"
+  value       = var.atlas_database_username
+}
+
+output "atlas_database_user_password" {
+  description = "MongoDB Atlas database user password"
+  value       = local.effective_database_user_password
+  sensitive   = true
+}

--- a/modules/mongodb-atlas/outputs.tf
+++ b/modules/mongodb-atlas/outputs.tf
@@ -1,31 +1,5 @@
-output "atlas_project_id" {
-  description = "MongoDB Atlas project ID"
-  value       = mongodbatlas_project.this.id
-}
-
-output "atlas_cluster_name" {
-  description = "MongoDB Atlas cluster name"
-  value       = mongodbatlas_cluster.this.name
-}
-
 output "atlas_connection_uri" {
-  description = "Connection string including credentials"
+  description = "Full connection string with credentials for Doppler"
   value       = "mongodb+srv://${var.atlas_database_username}:${urlencode(local.effective_database_user_password)}@${replace(mongodbatlas_cluster.this.connection_strings[0].standard_srv, "mongodb+srv://", "")}/${var.atlas_database_name}?retryWrites=true&w=majority"
-  sensitive   = true
-}
-
-output "atlas_connection_uri_srv" {
-  description = "SRV connection string without credentials"
-  value       = mongodbatlas_cluster.this.connection_strings[0].standard_srv
-}
-
-output "atlas_database_username" {
-  description = "MongoDB Atlas database user"
-  value       = var.atlas_database_username
-}
-
-output "atlas_database_user_password" {
-  description = "MongoDB Atlas database user password"
-  value       = local.effective_database_user_password
   sensitive   = true
 }

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -11,6 +11,7 @@ variable "atlas_project_name" {
 variable "atlas_cluster_name" {
   description = "MongoDB Atlas cluster name"
   type        = string
+  default     = "Cluster0"
 }
 
 variable "atlas_provider_name" {
@@ -28,7 +29,7 @@ variable "atlas_backing_provider_name" {
 variable "atlas_region" {
   description = "Atlas region for the cluster"
   type        = string
-  default     = "US_EAST_1"
+  default     = "AP_SOUTH_1"
 }
 
 variable "atlas_instance_size_name" {

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -1,0 +1,81 @@
+variable "atlas_org_id" {
+  description = "MongoDB Atlas organization ID"
+  type        = string
+}
+
+variable "atlas_public_key" {
+  description = "MongoDB Atlas public API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "atlas_private_key" {
+  description = "MongoDB Atlas private API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "atlas_project_name" {
+  description = "MongoDB Atlas project name"
+  type        = string
+}
+
+variable "atlas_cluster_name" {
+  description = "MongoDB Atlas cluster name"
+  type        = string
+}
+
+variable "atlas_provider_name" {
+  description = "Atlas provider name"
+  type        = string
+  default     = "TENANT"
+}
+
+variable "atlas_backing_provider_name" {
+  description = "Cloud provider for shared clusters"
+  type        = string
+  default     = "AWS"
+}
+
+variable "atlas_region" {
+  description = "Atlas region for the cluster"
+  type        = string
+  default     = "US_EAST_1"
+}
+
+variable "atlas_instance_size_name" {
+  description = "Atlas instance size (M0 for free tier)"
+  type        = string
+  default     = "M0"
+}
+
+variable "atlas_mongodb_major_version" {
+  description = "MongoDB major version"
+  type        = string
+  default     = "7.0"
+}
+
+variable "atlas_database_name" {
+  description = "Application database name"
+  type        = string
+  default     = "app"
+}
+
+variable "atlas_database_username" {
+  description = "Application database username"
+  type        = string
+  default     = "app"
+}
+
+variable "atlas_database_user_password" {
+  description = "Application database user password. If null, Terraform generates one"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "atlas_access_list_cidrs" {
+  description = "CIDR blocks allowed to connect to Atlas"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/modules/mongodb-atlas/variables.tf
+++ b/modules/mongodb-atlas/variables.tf
@@ -3,18 +3,6 @@ variable "atlas_org_id" {
   type        = string
 }
 
-variable "atlas_public_key" {
-  description = "MongoDB Atlas public API key"
-  type        = string
-  sensitive   = true
-}
-
-variable "atlas_private_key" {
-  description = "MongoDB Atlas private API key"
-  type        = string
-  sensitive   = true
-}
-
 variable "atlas_project_name" {
   description = "MongoDB Atlas project name"
   type        = string

--- a/modules/mongodb-atlas/versions.tf
+++ b/modules/mongodb-atlas/versions.tf
@@ -4,7 +4,6 @@ terraform {
       source  = "mongodb/mongodbatlas"
       version = "~> 1.20"
     }
-
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6"

--- a/modules/mongodb-atlas/versions.tf
+++ b/modules/mongodb-atlas/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 1.20"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,28 +6,8 @@ output "ingress_nginx_service_external_ip" {
   value = module.kubernetes.ingress_nginx_service_external_ip
 }
 
-output "atlas_project_id" {
-  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_project_id : null
-}
-
-output "atlas_cluster_name" {
-  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_cluster_name : null
-}
-
 output "atlas_connection_uri" {
-  value     = var.atlas_enabled ? module.atlas_mongodb[0].atlas_connection_uri : null
-  sensitive = true
-}
-
-output "atlas_connection_uri_srv" {
-  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_connection_uri_srv : null
-}
-
-output "atlas_database_username" {
-  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_database_username : null
-}
-
-output "atlas_database_user_password" {
-  value     = var.atlas_enabled ? module.atlas_mongodb[0].atlas_database_user_password : null
-  sensitive = true
+  description = "Full MongoDB URI with credentials for Doppler"
+  value       = var.atlas_enabled ? module.atlas_mongodb[0].atlas_connection_uri : null
+  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,29 @@ output "do_cluster_id" {
 output "ingress_nginx_service_external_ip" {
   value = module.kubernetes.ingress_nginx_service_external_ip
 }
+
+output "atlas_project_id" {
+  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_project_id : null
+}
+
+output "atlas_cluster_name" {
+  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_cluster_name : null
+}
+
+output "atlas_connection_uri" {
+  value     = var.atlas_enabled ? module.atlas_mongodb[0].atlas_connection_uri : null
+  sensitive = true
+}
+
+output "atlas_connection_uri_srv" {
+  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_connection_uri_srv : null
+}
+
+output "atlas_database_username" {
+  value = var.atlas_enabled ? module.atlas_mongodb[0].atlas_database_username : null
+}
+
+output "atlas_database_user_password" {
+  value     = var.atlas_enabled ? module.atlas_mongodb[0].atlas_database_user_password : null
+  sensitive = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,96 @@ variable "do_cluster_version" {
   # list is available at https://slugs.do-api.dev/ on "Kubernetes Versions"
   description = "The slug identifier for the version of Kubernetes used for the cluster"
 }
+
+variable "atlas_enabled" {
+  description = "Enable MongoDB Atlas provisioning"
+  type        = bool
+  default     = false
+}
+
+variable "atlas_org_id" {
+  description = "MongoDB Atlas organization ID"
+  type        = string
+  default     = ""
+}
+
+variable "atlas_public_key" {
+  description = "MongoDB Atlas public API key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "atlas_private_key" {
+  description = "MongoDB Atlas private API key"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "atlas_project_name" {
+  description = "MongoDB Atlas project name"
+  type        = string
+  default     = "platform-apps"
+}
+
+variable "atlas_cluster_name" {
+  description = "MongoDB Atlas cluster name"
+  type        = string
+  default     = "shared-free-cluster"
+}
+
+variable "atlas_provider_name" {
+  description = "MongoDB Atlas provider name"
+  type        = string
+  default     = "TENANT"
+}
+
+variable "atlas_backing_provider_name" {
+  description = "Cloud provider backing Atlas shared clusters"
+  type        = string
+  default     = "AWS"
+}
+
+variable "atlas_region" {
+  description = "MongoDB Atlas region for the cluster"
+  type        = string
+  default     = "US_EAST_1"
+}
+
+variable "atlas_instance_size_name" {
+  description = "MongoDB Atlas instance size"
+  type        = string
+  default     = "M0"
+}
+
+variable "atlas_mongodb_major_version" {
+  description = "MongoDB Atlas major version"
+  type        = string
+  default     = "7.0"
+}
+
+variable "atlas_database_name" {
+  description = "MongoDB database name for app access"
+  type        = string
+  default     = "app"
+}
+
+variable "atlas_database_username" {
+  description = "MongoDB database username for app access"
+  type        = string
+  default     = "app"
+}
+
+variable "atlas_database_user_password" {
+  description = "MongoDB database user password. If null, Terraform generates one"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "atlas_access_list_cidrs" {
+  description = "CIDR blocks allowed to connect to MongoDB Atlas"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable "atlas_project_name" {
 variable "atlas_cluster_name" {
   description = "MongoDB Atlas cluster name"
   type        = string
-  default     = "shared-free-cluster"
+  default     = "Cluster0"
 }
 
 variable "atlas_provider_name" {
@@ -72,7 +72,7 @@ variable "atlas_backing_provider_name" {
 variable "atlas_region" {
   description = "MongoDB Atlas region for the cluster"
   type        = string
-  default     = "US_EAST_1"
+  default     = "AP_SOUTH_1"
 }
 
 variable "atlas_instance_size_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,18 @@ variable "cluster_issuer_email" {
   description = "Email address used for ACME registration for Kubernetes CertManager service"
 }
 
+variable "enable_preview_pool" {
+  description = "Terraform Cloud preview pool setting (organization-level)"
+  type        = bool
+  default     = false
+}
+
+variable "preview_node_size" {
+  description = "Terraform Cloud preview node size (organization-level)"
+  type        = string
+  default     = ""
+}
+
 variable "do_cluster_name" {
   description = "Kubernetes cluster name on DigitalOcean"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,11 @@ terraform {
       version = "~> 2.0"
     }
 
+    mongodbatlas = {
+      source  = "mongodb/mongodbatlas"
+      version = "~> 1.20"
+    }
+
     helm = {
       source  = "hashicorp/helm"
       version = "2.5.1"


### PR DESCRIPTION
## Summary

**What does this PR change and why?**

This PR automates MongoDB Atlas provisioning via Terraform. When setting up a new project, the platform team no longer needs to manually create an Atlas cluster in the jalantechnologies org.

**Changes:**
- Create Atlas project, free-tier cluster (M0), database user, and IP access list through Terraform
- Output `atlas_connection_uri` (full URI with credentials) for Doppler integration
- Default region: AP_SOUTH_1 (Mumbai), default cluster name: Cluster0
- Atlas provisioning is optional via `atlas_enabled` flag
- Database user and password are created by Terraform (password auto-generated if not provided)

**Required variables when Atlas is enabled:** `atlas_org_id`, `atlas_public_key`, `atlas_private_key`


---

## Additional Context

Video Walkthrough: https://www.loom.com/share/1064411fd7c245d2a309820b29b185b3
- Tested with `terraform plan -target=module.atlas_mongodb` and `terraform apply -target=module.atlas_mongodb`
- Atlas resources created successfully: project, cluster (Cluster0), database user, IP access list
- Output `atlas_connection_uri` verified for Doppler usage
<img width="1917" height="980" alt="image" src="https://github.com/user-attachments/assets/ebd6d96b-0959-4a9f-b6c4-ea8734c3141c" />
